### PR TITLE
Added fallback caption-fetch url

### DIFF
--- a/captions/youtube_util/jsonripsubs.py
+++ b/captions/youtube_util/jsonripsubs.py
@@ -3,8 +3,11 @@ import os
 
 infile = open('subsscrapelist.txt', 'r')
 
-#for id in infile:
 for id in infile.readlines():
-    id = id[:-1] #trim off newline
+    # trim off # comments
+    if id.find('#') != -1:
+        id = id[:id.find('#')]
+    # newline cleanup
+    id = id.strip()
     if id:
-        os.system("python get_json_subs.py "+id);
+        os.system("python get_json_subs.py " + id);


### PR DESCRIPTION
This fixed a particular set of broken captions
we had in production. It always tries the old
way first, so it should not break anything.

Also extended the jsonripsubs.py code to not
depend on that last newline, and to
to support # comments.
